### PR TITLE
COmpatibility with Raspberry pi 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /venv/
+config.json
 tweet-toot/config.json
 
 # Byte-compiled / optimized / DLL files

--- a/tweet-toot/config.json
+++ b/tweet-toot/config.json
@@ -1,8 +1,8 @@
 {
     "TT_APP_NAME": "Tweet-Toot",
-    "TT_SOURCE_TWITTER_URL": "https://twitter.com/internetofshit",
+    "TT_SOURCE_TWITTER_URL": "https://twitter.com/EuroSciPy",
     "TT_HOST_INSTANCE": "https://botsin.space",
-    "TT_APP_SECURE_TOKEN": "",
+    "TT_APP_SECURE_TOKEN": "8z1O8G4H2zkSEy7g7hrIwrO8317ZcjF6vv5Uo76RS-o",
     "TT_CACHE_PATH": "/tmp/",
     "TT_MODE": "one-to-one"
 }

--- a/tweet-toot/config.json
+++ b/tweet-toot/config.json
@@ -1,8 +1,0 @@
-{
-    "TT_APP_NAME": "Tweet-Toot",
-    "TT_SOURCE_TWITTER_URL": "https://twitter.com/EuroSciPy,https://twitter.com/CaptainFact_io",
-    "TT_HOST_INSTANCE": "https://botsin.space,https://mamot.fr",
-    "TT_APP_SECURE_TOKEN": "<token1>,<token2>",
-    "TT_CACHE_PATH": "/tmp/",
-    "TT_MODE": "one-to-one"
-}

--- a/tweet-toot/config.json
+++ b/tweet-toot/config.json
@@ -1,8 +1,8 @@
 {
     "TT_APP_NAME": "Tweet-Toot",
-    "TT_SOURCE_TWITTER_URL": "https://twitter.com/EuroSciPy",
-    "TT_HOST_INSTANCE": "https://botsin.space",
-    "TT_APP_SECURE_TOKEN": "8z1O8G4H2zkSEy7g7hrIwrO8317ZcjF6vv5Uo76RS-o",
+    "TT_SOURCE_TWITTER_URL": "https://twitter.com/EuroSciPy,https://twitter.com/CaptainFact_io",
+    "TT_HOST_INSTANCE": "https://botsin.space,https://mamot.fr",
+    "TT_APP_SECURE_TOKEN": "<token1>,<token2>",
     "TT_CACHE_PATH": "/tmp/",
     "TT_MODE": "one-to-one"
 }

--- a/tweet-toot/helpers.py
+++ b/tweet-toot/helpers.py
@@ -44,7 +44,7 @@ def _config(key):
     else:
 
         logger.critical(
-            f"{key} not found in config.json or in the environment. Exiting."
+            "{} not found in config.json or in the environment. Exiting.".format(key)
         )
         sys.exit()
 

--- a/tweet-toot/run.py
+++ b/tweet-toot/run.py
@@ -33,12 +33,12 @@ if __name__ == "__main__":
     if len(mastodon_url) != len(mastodon_token):
 
         logger.error(
-            f"Lenghts of Mastodon URL ({len(mastodon_url)}) and Mastodon tokens ({len(mastodon_url)}) do not match."
+            "Lenghts of Mastodon URL ({}) and Mastodon tokens ({}) do not match.".format(len(mastodon_url), len(mastodon_url))
         )
 
     else:
 
-        logger.info(f"__main__ => Mode: {mode}")
+        logger.info("__main__ => Mode: {}".format(mode))
 
         if mode == "one-to-one":
 
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             if len(twitter_url) != len(mastodon_url):
 
                 logger.error(
-                    f"In {mode}, the number of Twitter URLs and Mastodon hosts should be the same."
+                    "In {}, the number of Twitter URLs and Mastodon hosts should be the same.".format(mode)
                 )
 
                 sys.exit(0)
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
             if len(twitter_url) == 1:
 
-                logger.error(f"In {mode}, there can only be 1 Twitter URL.")
+                logger.error("In {}, there can only be 1 Twitter URL.".format(mode))
 
                 sys.exit(0)
 
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 
             if len(mastodon_url) != 1:
 
-                logger.error(f"In {mode}, there can only be 1 Mastodon host.")
+                logger.error("In {}, there can only be 1 Mastodon host.".format(mode))
 
                 sys.exit(0)
 
@@ -93,7 +93,7 @@ if __name__ == "__main__":
 
         else:
 
-            logger.critical(f"__main__ => {mode} incorrect.")
+            logger.critical("__main__ => {} incorrect.".format(mode))
 
             sys.exit(0)
 

--- a/tweet-toot/tweettoot.py
+++ b/tweet-toot/tweettoot.py
@@ -34,38 +34,38 @@ class TweetToot:
 
         :type self:
         :param self:
-    
+
         :raises:
-    
+
         :rtype: bool
         """
 
         if not self.app_name:
 
-            logger.error(f"relay() => Application name in config is incorrect/empty.")
+            logger.error("relay() => Application name in config is incorrect/empty.")
 
             return False
 
         if not self.twitter_url:
 
-            logger.error(f"relay() => Twitter URL in config is incorrect/empty.")
+            logger.error("relay() => Twitter URL in config is incorrect/empty.")
 
             return False
 
         if not self.mastodon_url:
 
-            logger.error(f"relay() => Mastodon URL in config is incorrect/empty.")
+            logger.error("relay() => Mastodon URL in config is incorrect/empty.")
 
             return False
 
         if not self.mastodon_token:
 
-            logger.error(f"relay() => Mastodon token in config is incorrect/empty.")
+            logger.error("relay() => Mastodon token in config is incorrect/empty.")
 
             return False
 
         logger.info(
-            f"relay() => Init relay from {self.twitter_url} to {self.mastodon_url}. State file {self._get_timestamp_file_path()}"
+            "relay() => Init relay from {} to {}. State file {}".format(self.twitter_url, self.mastodon_url, self._get_timestamp_file_path())
         )
 
         tweets = self._get_tweets()
@@ -74,11 +74,11 @@ class TweetToot:
 
             return True
 
-        logger.debug(f"relay() => {str(tweets)}")
+        logger.debug("relay() => {}".format(str(tweets)))
 
         for tweet_time, tweet in tweets.items():
 
-            logger.info(f"relay() => Tweeting {tweet['id']} to {self.mastodon_url}")
+            logger.info("relay() => Tweeting {} to {}".format(tweet['id'], self.mastodon_url))
 
             self._toot_the_tweet(
                 mastodon_url=self.mastodon_url,
@@ -116,12 +116,12 @@ class TweetToot:
         if timeline is None:
 
             logger.error(
-                f"get_tweets() => Could not retrieve tweets from the page. Please make sure the source Twitter URL ({self.twitter_url}) is correct."
+                "get_tweets() => Could not retrieve tweets from the page. Please make sure the source Twitter URL ({}) is correct.".format(self.twitter_url)
             )
             return False
 
         logger.info(
-            f"get_tweets() => Fetched {len(tweets)} new tweets for {self.twitter_url}."
+            "get_tweets() => Fetched {} new tweets for {}.".format(len(tweets), self.twitter_url)
         )
 
         for tweet in timeline:
@@ -210,26 +210,26 @@ class TweetToot:
         """ Receieve a dictionary containing Tweet ID and text... and TOOT!
         This function relies on the requests library to post the content to your Mastodon account (human or bot).
         A boolean success status is returned.
-            
+
         :type self:
         :param self:
-    
+
         :type tweet_id:str:
         :param tweet_id:str: Tweet ID.
-    
+
         :type tweet_body:str:
         :param tweet_body:str: Tweet text.
-    
+
         :type tweet_time:int:
         :param tweet_time:int: Tweet timestamp.
 
         :raises:
-    
+
         :rtype: bool
         """
 
         headers = {}
-        headers["Authorization"] = f"Bearer {self.mastodon_token}"
+        headers["Authorization"] = "Bearer {}".format(self.mastodon_token)
         headers["Idempotency-Key"] = tweet_id
 
         data = {}
@@ -237,15 +237,15 @@ class TweetToot:
         data["visibility"] = "public"
 
         response = requests.post(
-            url=f"{mastodon_url}/api/v1/statuses", data=data, headers=headers
+            url="{}/api/v1/statuses".format(mastodon_url), data=data, headers=headers
         )
 
         if response.status_code == 200:
 
             logger.info(
-                f"toot_the_tweet() => OK. Tooted {tweet_id} to {self.mastodon_url}."
+                "toot_the_tweet() => OK. Tooted {} to {}.".format(tweet_id, self.mastodon_url)
             )
-            logger.debug(f"toot_the_tweet() => Response: {response.text}")
+            logger.debug("toot_the_tweet() => Response: {}".format(response.text))
 
             self._set_last_timestamp(timestamp=tweet_time)
 
@@ -254,8 +254,8 @@ class TweetToot:
         else:
 
             logger.error(
-                f"toot_the_tweet() => Could not toot {tweet_id} to {self.mastodon_url}."
+                "toot_the_tweet() => Could not toot {} to {self.mastodon_url}.".format(tweet_id)
             )
-            logger.debug(f"toot_the_tweet() => Response: {response.text}")
+            logger.debug("toot_the_tweet() => Response: {}".format(response.text))
 
             return False


### PR DESCRIPTION
Dear @ayush-sharma , 

I have made minor changes to branch develop just to make it compatible with low-level hardware like the rapsberry pi 4 which cannot handle python 3.7 and is limited to python 3.4.
It basically means it can't handle modern string formatting : 

f'blablabl {variable1} blablabla'  truned into 'blablabla {} blablabla'.format(variable1)

I changed all concerned strings in all files, but that's all I changed.

Also, I merged your last changes to develop to test (see terminal log below):
* It posted nothing to the bot, but I think that's because there is no new tweet sonce last time, and it's ok since it should not post several times the same tweets (could you check though?).

Test with Eoruscipy only:
```
pi@raspberrypi:~/Twitter2Mastodon/tweet-toot/tweet-toot (develop) $ python run.py
2020-05-10 20:51:19,701 - __main__ - INFO - __main__ => Mode: one-to-one
2020-05-10 20:51:19,702 - tweettoot - INFO - relay() => Init relay from https://twitter.com/EuroSciPy to https://botsin.space. State file /tmp/tt_b67df4aa5c823c5c3d3c22aa28e4e1c73a86dbe5
2020-05-10 20:51:19,726 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): twitter.com
2020-05-10 20:51:21,639 - tweettoot - INFO - get_tweets() => Fetched 20 new tweets for https://twitter.com/EuroSciPy.
2020-05-10 20:51:21,989 - tweettoot - INFO - relay() => Tweeting 1230060371114954752 to https://botsin.space
2020-05-10 20:51:21,993 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:22,622 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1230060371114954752 to https://botsin.space.
2020-05-10 20:51:22,623 - tweettoot - INFO - relay() => Tweeting 1235987701297487873 to https://botsin.space
2020-05-10 20:51:22,626 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:23,126 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1235987701297487873 to https://botsin.space.
2020-05-10 20:51:23,129 - tweettoot - INFO - relay() => Tweeting 1231569185458790400 to https://botsin.space
2020-05-10 20:51:23,137 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:23,668 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1231569185458790400 to https://botsin.space.
2020-05-10 20:51:23,671 - tweettoot - INFO - relay() => Tweeting 1251268988912443395 to https://botsin.space
2020-05-10 20:51:23,679 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:24,226 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1251268988912443395 to https://botsin.space.
2020-05-10 20:51:24,228 - tweettoot - INFO - relay() => Tweeting 1234538966906527752 to https://botsin.space
2020-05-10 20:51:24,231 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:24,743 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1234538966906527752 to https://botsin.space.
2020-05-10 20:51:24,747 - tweettoot - INFO - relay() => Tweeting 1235868034062880768 to https://botsin.space
2020-05-10 20:51:24,754 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:25,311 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1235868034062880768 to https://botsin.space.
2020-05-10 20:51:25,314 - tweettoot - INFO - relay() => Tweeting 1235112746988875777 to https://botsin.space
2020-05-10 20:51:25,322 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:25,899 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1235112746988875777 to https://botsin.space.
2020-05-10 20:51:25,901 - tweettoot - INFO - relay() => Tweeting 1240399282995421190 to https://botsin.space
2020-05-10 20:51:25,904 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:26,775 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1240399282995421190 to https://botsin.space.
2020-05-10 20:51:26,779 - tweettoot - INFO - relay() => Tweeting 1253737600466276352 to https://botsin.space
2020-05-10 20:51:26,787 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:27,314 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1253737600466276352 to https://botsin.space.
2020-05-10 20:51:27,317 - tweettoot - INFO - relay() => Tweeting 1230798932449644544 to https://botsin.space
2020-05-10 20:51:27,325 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:27,894 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1230798932449644544 to https://botsin.space.
2020-05-10 20:51:27,897 - tweettoot - INFO - relay() => Tweeting 1234428825464909825 to https://botsin.space
2020-05-10 20:51:27,905 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): botsin.space
2020-05-10 20:51:28,476 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1234428825464909825 to https://botsin.space.
```

Then I tried adding a second twitter / mastodon pair of accounts following your readme: it worked :+1: .
However, I feel the sane problem occured again: the order in which the toots appear on the [mastodon instance](https://mamot.fr/web/accounts/305043) is not the same as the order in which they were [twitted](https://twitter.com/CaptainFact_io). Any idea why ?

```
pi@raspberrypi:~/Twitter2Mastodon/tweet-toot/tweet-toot (develop) $ python run.py
2020-05-10 21:13:37,606 - __main__ - INFO - __main__ => Mode: one-to-one
2020-05-10 21:13:37,606 - tweettoot - INFO - relay() => Init relay from https://twitter.com/EuroSciPy to https://botsin.space. State file /tmp/tt_b67df4aa5c823c5c3d3c22aa28e4e1c73a86dbe5
2020-05-10 21:13:37,630 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): twitter.com
2020-05-10 21:13:39,631 - tweettoot - INFO - get_tweets() => Fetched 20 new tweets for https://twitter.com/EuroSciPy.
2020-05-10 21:13:39,869 - tweettoot - INFO - relay() => Init relay from https://twitter.com/CaptainFact_io to https://mamot.fr. State file /tmp/tt_737c383200799cc0854fe3efa12c6d2e9f989885
2020-05-10 21:13:39,874 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): twitter.com
2020-05-10 21:13:41,799 - tweettoot - INFO - get_tweets() => Fetched 21 new tweets for https://twitter.com/CaptainFact_io.
2020-05-10 21:13:42,252 - tweettoot - INFO - relay() => Tweeting 1256181831822708736 to https://mamot.fr
2020-05-10 21:13:42,255 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:43,111 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1256181831822708736 to https://mamot.fr.
2020-05-10 21:13:43,112 - tweettoot - INFO - relay() => Tweeting 1257703590640091136 to https://mamot.fr
2020-05-10 21:13:43,120 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:44,122 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257703590640091136 to https://mamot.fr.
2020-05-10 21:13:44,123 - tweettoot - INFO - relay() => Tweeting 1259559146749378562 to https://mamot.fr
2020-05-10 21:13:44,131 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:44,796 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1259559146749378562 to https://mamot.fr.
2020-05-10 21:13:44,797 - tweettoot - INFO - relay() => Tweeting 1254336401006628870 to https://mamot.fr
2020-05-10 21:13:44,801 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:45,672 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1254336401006628870 to https://mamot.fr.
2020-05-10 21:13:45,675 - tweettoot - INFO - relay() => Tweeting 1257952938535858176 to https://mamot.fr
2020-05-10 21:13:45,684 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:46,121 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257952938535858176 to https://mamot.fr.
2020-05-10 21:13:46,123 - tweettoot - INFO - relay() => Tweeting 1253782338850508800 to https://mamot.fr
2020-05-10 21:13:46,126 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:46,493 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1253782338850508800 to https://mamot.fr.
2020-05-10 21:13:46,495 - tweettoot - INFO - relay() => Tweeting 1126934452247121920 to https://mamot.fr
2020-05-10 21:13:46,499 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:47,133 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1126934452247121920 to https://mamot.fr.
2020-05-10 21:13:47,135 - tweettoot - INFO - relay() => Tweeting 1258775389670965250 to https://mamot.fr
2020-05-10 21:13:47,138 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:47,542 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1258775389670965250 to https://mamot.fr.
2020-05-10 21:13:47,546 - tweettoot - INFO - relay() => Tweeting 1257935164287713280 to https://mamot.fr
2020-05-10 21:13:47,554 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:48,311 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257935164287713280 to https://mamot.fr.
2020-05-10 21:13:48,313 - tweettoot - INFO - relay() => Tweeting 1257919177152696322 to https://mamot.fr
2020-05-10 21:13:48,316 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:49,230 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257919177152696322 to https://mamot.fr.
2020-05-10 21:13:49,233 - tweettoot - INFO - relay() => Tweeting 1254007506420092928 to https://mamot.fr
2020-05-10 21:13:49,242 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:49,967 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1254007506420092928 to https://mamot.fr.
2020-05-10 21:13:49,968 - tweettoot - INFO - relay() => Tweeting 1258718545967489024 to https://mamot.fr
2020-05-10 21:13:49,972 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:50,630 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1258718545967489024 to https://mamot.fr.
2020-05-10 21:13:50,633 - tweettoot - INFO - relay() => Tweeting 1257745636209963009 to https://mamot.fr
2020-05-10 21:13:50,641 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:51,155 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257745636209963009 to https://mamot.fr.
2020-05-10 21:13:51,157 - tweettoot - INFO - relay() => Tweeting 1258655449634803714 to https://mamot.fr
2020-05-10 21:13:51,161 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:51,420 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1258655449634803714 to https://mamot.fr.
2020-05-10 21:13:51,422 - tweettoot - INFO - relay() => Tweeting 1257708139501236225 to https://mamot.fr
2020-05-10 21:13:51,425 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:52,057 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1257708139501236225 to https://mamot.fr.
2020-05-10 21:13:52,058 - tweettoot - INFO - relay() => Tweeting 1258323821544771584 to https://mamot.fr
2020-05-10 21:13:52,061 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:52,623 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1258323821544771584 to https://mamot.fr.
2020-05-10 21:13:52,626 - tweettoot - INFO - relay() => Tweeting 1254050394856136706 to https://mamot.fr
2020-05-10 21:13:52,634 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:53,849 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1254050394856136706 to https://mamot.fr.
2020-05-10 21:13:53,853 - tweettoot - INFO - relay() => Tweeting 1255202710703558656 to https://mamot.fr
2020-05-10 21:13:53,861 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:56,293 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1255202710703558656 to https://mamot.fr.
2020-05-10 21:13:56,297 - tweettoot - INFO - relay() => Tweeting 1258103936663400449 to https://mamot.fr
2020-05-10 21:13:56,305 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:56,863 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1258103936663400449 to https://mamot.fr.
2020-05-10 21:13:56,865 - tweettoot - INFO - relay() => Tweeting 1255123341477851136 to https://mamot.fr
2020-05-10 21:13:56,868 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:57,295 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1255123341477851136 to https://mamot.fr.
2020-05-10 21:13:57,297 - tweettoot - INFO - relay() => Tweeting 1255466641640562688 to https://mamot.fr
2020-05-10 21:13:57,300 - requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): mamot.fr
2020-05-10 21:13:57,749 - tweettoot - INFO - toot_the_tweet() => OK. Tooted 1255466641640562688 to https://mamot.fr.
```

Also, for readability purposes in the config.json file.
Maybe we could strip the strings of their empty spaces ' ' when reading them ?
It would allow users to add spaces after commas (for readability) and the code to still correctly interpret the string, your opinion ?




 